### PR TITLE
Fix deeplearning autoencoder implementation issues

### DIFF
--- a/bluemath_tk/deeplearning/_base_model.py
+++ b/bluemath_tk/deeplearning/_base_model.py
@@ -1,3 +1,4 @@
+import copy
 from abc import abstractmethod
 from typing import Dict, Optional, Union
 
@@ -202,7 +203,7 @@ class BaseDeepLearningModel(BlueMathModel):
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
                 patience_counter = 0
-                best_model_state = self.model.state_dict().copy()
+                best_model_state = copy.deepcopy(self.model.state_dict())
             else:
                 patience_counter += 1
                 if patience_counter >= patience:

--- a/bluemath_tk/deeplearning/autoencoders.py
+++ b/bluemath_tk/deeplearning/autoencoders.py
@@ -20,6 +20,7 @@ Each autoencoder is a subclass of BaseDeepLearningModel and implements the follo
 - evaluate(X)
 """
 
+import copy
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -91,17 +92,20 @@ class StandardAutoencoder(BaseDeepLearningModel):
 
     def _build_model(self, input_shape: Tuple, **kwargs) -> nn.Module:
         """Build the standard fully-connected autoencoder model."""
-        # Handle input shape: (n_samples, n_features) or (n_features,)
+        # Handle input shape: (n_samples, ...) or a single sample shape.
+        # For fit(X), input_shape includes the batch dimension, so the
+        # per-sample shape is input_shape[1:].
         if len(input_shape) == 1:
-            n_features = input_shape[0]
+            sample_shape = (input_shape[0],)
         else:
-            # Take last dimension as features (handles (n_samples, n_features))
-            n_features = input_shape[-1]
+            sample_shape = tuple(input_shape[1:])
+        n_features = int(np.prod(sample_shape))
 
         class StandardAutoencoderModel(nn.Module):
-            def __init__(self, n_features, hidden_dims, k):
+            def __init__(self, n_features, hidden_dims, k, sample_shape):
                 super().__init__()
                 self.n_features = n_features
+                self.sample_shape = tuple(sample_shape)
                 # Encoder
                 encoder_layers = []
                 prev_dim = n_features
@@ -132,7 +136,7 @@ class StandardAutoencoder(BaseDeepLearningModel):
                     x = x.unsqueeze(0)
                 z = self.encoder(x)
                 x_recon = self.decoder(z)
-                return x_recon
+                return x_recon.view(x_recon.size(0), *self.sample_shape)
 
             def encode_forward(self, x):
                 """Encode input to latent space."""
@@ -142,7 +146,7 @@ class StandardAutoencoder(BaseDeepLearningModel):
                     x = x.unsqueeze(0)
                 return self.encoder(x)
 
-        return StandardAutoencoderModel(n_features, self.hidden_dims, self.k)
+        return StandardAutoencoderModel(n_features, self.hidden_dims, self.k, sample_shape)
 
 
 class OrthogonalAutoencoder(BaseDeepLearningModel):
@@ -204,16 +208,22 @@ class OrthogonalAutoencoder(BaseDeepLearningModel):
 
     def _build_model(self, input_shape: Tuple, **kwargs) -> nn.Module:
         """Build the orthogonal autoencoder model."""
-        # Handle input shape: (n_samples, n_features) or (n_features,)
+        # Handle input shape: (n_samples, ...) or a single sample shape.
+        # For fit(X), input_shape includes the batch dimension, so the
+        # per-sample shape is input_shape[1:].
         if len(input_shape) == 1:
-            n_features = input_shape[0]
+            sample_shape = (input_shape[0],)
         else:
-            n_features = input_shape[-1]
+            sample_shape = tuple(input_shape[1:])
+        n_features = int(np.prod(sample_shape))
 
         class OrthogonalAutoencoderModel(nn.Module):
-            def __init__(self, n_features, hidden_dims, k, lambda_W, lambda_Z):
+            def __init__(
+                self, n_features, hidden_dims, k, lambda_W, lambda_Z, sample_shape
+            ):
                 super().__init__()
                 self.n_features = n_features
+                self.sample_shape = tuple(sample_shape)
                 self.lambda_W = lambda_W
                 self.lambda_Z = lambda_Z
 
@@ -265,7 +275,7 @@ class OrthogonalAutoencoder(BaseDeepLearningModel):
                 z = z + 0 * ortho_loss
 
                 x_recon = self.decoder(z)
-                return x_recon
+                return x_recon.view(x_recon.size(0), *self.sample_shape)
 
             def encode_forward(self, x):
                 """Encode input to latent space."""
@@ -287,7 +297,12 @@ class OrthogonalAutoencoder(BaseDeepLearningModel):
                 return ortho_loss, decorr_loss
 
         return OrthogonalAutoencoderModel(
-            n_features, self.hidden_dims, self.k, self.lambda_W, self.lambda_Z
+            n_features,
+            self.hidden_dims,
+            self.k,
+            self.lambda_W,
+            self.lambda_Z,
+            sample_shape,
         )
 
     def fit(
@@ -410,7 +425,7 @@ class OrthogonalAutoencoder(BaseDeepLearningModel):
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
                 patience_counter = 0
-                best_model_state = self.model.state_dict().copy()
+                best_model_state = copy.deepcopy(self.model.state_dict())
             else:
                 patience_counter += 1
                 if patience_counter >= patience:
@@ -838,6 +853,7 @@ class VisionTransformerAutoencoder(BaseDeepLearningModel):
                 self.H = H
                 self.W = W
                 self.C = C
+                self.d_model = d_model
 
                 # Patchify + embed + pos
                 self.patchify = Patchify(patch_size)
@@ -879,6 +895,7 @@ class VisionTransformerAutoencoder(BaseDeepLearningModel):
                         )
                     )
                 self.decoder_blocks = nn.Sequential(*decoder_blocks)
+                self.patch_reconstruct = nn.Linear(d_model, Pdim)
 
                 # Reconstruct patches
                 self.unpatchify = Unpatchify(patch_size, Hp, Wp, C)
@@ -930,7 +947,8 @@ class VisionTransformerAutoencoder(BaseDeepLearningModel):
                     y = block(y)
 
                 # Reconstruct patches
-                rec_patches = self.unpatchify(y)  # (B, C, H+pad_h, W+pad_w)
+                patch_tokens = self.patch_reconstruct(y)  # (B, N, Pdim)
+                rec_patches = self.unpatchify(patch_tokens)  # (B, C, H+pad_h, W+pad_w)
 
                 # Crop padding
                 if self.pad_h > 0 or self.pad_w > 0:
@@ -1036,6 +1054,47 @@ class ConvLSTMAutoencoder(BaseDeepLearningModel):
         self.k = k
         super().__init__(device=device, **kwargs)
 
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        validation_split: float = 0.2,
+        epochs: int = 500,
+        batch_size: int = 64,
+        learning_rate: float = 1e-3,
+        optimizer: Optional[torch.optim.Optimizer] = None,
+        criterion: Optional[nn.Module] = None,
+        patience: int = 20,
+        verbose: int = 1,
+        **kwargs,
+    ) -> Dict[str, list]:
+        """Fit the ConvLSTM autoencoder.
+
+        If ``y`` is not provided, the model reconstructs the last frame of each
+        input sequence, matching the documented prediction shape ``(B, C, H, W)``.
+        """
+        if y is None:
+            if X.ndim != 5:
+                raise ValueError(
+                    "ConvLSTMAutoencoder expects 5D input "
+                    "(n_samples, seq_len, C, H, W)."
+                )
+            y = X[:, -1]
+
+        return super().fit(
+            X,
+            y=y,
+            validation_split=validation_split,
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            optimizer=optimizer,
+            criterion=criterion,
+            patience=patience,
+            verbose=verbose,
+            **kwargs,
+        )
+
     def _build_model(self, input_shape: Tuple, **kwargs) -> nn.Module:
         """Build the ConvLSTM autoencoder model."""
         # Parse input shape: (n_samples, seq_len, C, H, W) - channels-first format
@@ -1068,7 +1127,7 @@ class ConvLSTMAutoencoder(BaseDeepLearningModel):
                 self.convlstm1 = ConvLSTM(
                     input_dim=C,
                     hidden_dim=32,
-                    kernel_size=3,
+                    kernel_size=(3, 3),
                     num_layers=1,
                     batch_first=True,
                     return_all_layers=False,
@@ -1077,7 +1136,7 @@ class ConvLSTMAutoencoder(BaseDeepLearningModel):
                 self.convlstm2 = ConvLSTM(
                     input_dim=32,
                     hidden_dim=32,
-                    kernel_size=3,
+                    kernel_size=(3, 3),
                     num_layers=1,
                     batch_first=True,
                     return_all_layers=False,
@@ -1276,6 +1335,47 @@ class HybridConvLSTMTransformerAutoencoder(BaseDeepLearningModel):
         self.k = k
         super().__init__(device=device, **kwargs)
 
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        validation_split: float = 0.2,
+        epochs: int = 500,
+        batch_size: int = 64,
+        learning_rate: float = 1e-3,
+        optimizer: Optional[torch.optim.Optimizer] = None,
+        criterion: Optional[nn.Module] = None,
+        patience: int = 20,
+        verbose: int = 1,
+        **kwargs,
+    ) -> Dict[str, list]:
+        """Fit the hybrid ConvLSTM-Transformer autoencoder.
+
+        If ``y`` is not provided, the model reconstructs the last frame of each
+        input sequence, matching the documented prediction shape ``(B, C, H, W)``.
+        """
+        if y is None:
+            if X.ndim != 5:
+                raise ValueError(
+                    "HybridConvLSTMTransformerAutoencoder expects 5D input "
+                    "(n_samples, seq_len, C, H, W)."
+                )
+            y = X[:, -1]
+
+        return super().fit(
+            X,
+            y=y,
+            validation_split=validation_split,
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            optimizer=optimizer,
+            criterion=criterion,
+            patience=patience,
+            verbose=verbose,
+            **kwargs,
+        )
+
     def _build_model(self, input_shape: Tuple, **kwargs) -> nn.Module:
         """Build the hybrid autoencoder model."""
         # Parse input shape: (n_samples, seq_len, C, H, W) - channels-first format
@@ -1314,6 +1414,7 @@ class HybridConvLSTMTransformerAutoencoder(BaseDeepLearningModel):
                 self.H = H
                 self.W = W
                 self.C = C
+                self.efficient_attention = efficient_attention
 
                 # ConvLSTM stack
                 from .layers import ConvLSTM
@@ -1321,7 +1422,7 @@ class HybridConvLSTMTransformerAutoencoder(BaseDeepLearningModel):
                 self.convlstm1 = ConvLSTM(
                     input_dim=C,
                     hidden_dim=32,
-                    kernel_size=3,
+                    kernel_size=(3, 3),
                     num_layers=1,
                     batch_first=True,
                     return_all_layers=True,
@@ -1329,7 +1430,7 @@ class HybridConvLSTMTransformerAutoencoder(BaseDeepLearningModel):
                 self.convlstm2 = ConvLSTM(
                     input_dim=32,
                     hidden_dim=32,
-                    kernel_size=3,
+                    kernel_size=(3, 3),
                     num_layers=1,
                     batch_first=True,
                     return_all_layers=True,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -ra

--- a/tests/test_deeplearning_autoencoders.py
+++ b/tests/test_deeplearning_autoencoders.py
@@ -1,0 +1,274 @@
+"""
+Smoke tests for BlueMath_tk autoencoders.
+
+These tests are intentionally small so they can run quickly in CI and in a local
+Anaconda environment.
+
+Run from the repository root with:
+
+    pytest -q tests/test_deeplearning_autoencoders.py
+
+Some tests are marked xfail because they document likely current bugs in the
+implementation. After fixing each issue, remove the corresponding xfail marker.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bluemath_tk.deeplearning.autoencoders import (
+    CNNAutoencoder,
+    ConvLSTMAutoencoder,
+    HybridConvLSTMTransformerAutoencoder,
+    LSTMAutoencoder,
+    OrthogonalAutoencoder,
+    StandardAutoencoder,
+)
+
+
+@pytest.fixture(autouse=True)
+def _set_reproducible_seed():
+    """Keep tests deterministic and avoid excessive CPU thread use."""
+    np.random.seed(123)
+    torch.manual_seed(123)
+    torch.set_num_threads(1)
+
+
+def _fit_kwargs():
+    """Common tiny training configuration."""
+    return dict(
+        epochs=1,
+        batch_size=4,
+        validation_split=0.25,
+        patience=2,
+        verbose=0,
+        learning_rate=1e-3,
+    )
+
+
+def test_standard_autoencoder_fit_predict_encode_shapes():
+    """StandardAutoencoder should reconstruct 2D tabular input."""
+    X = np.random.randn(16, 10).astype("float32")
+
+    ae = StandardAutoencoder(
+        k=3,
+        hidden_dims=[8],
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert len(history["train_loss"]) >= 1
+    assert len(history["val_loss"]) >= 1
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 3)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+def test_orthogonal_autoencoder_fit_predict_encode_shapes():
+    """OrthogonalAutoencoder should reconstruct 2D tabular input."""
+    X = np.random.randn(16, 10).astype("float32")
+
+    ae = OrthogonalAutoencoder(
+        k=3,
+        hidden_dims=[8],
+        lambda_W=1e-4,
+        lambda_Z=1e-4,
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 3)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+def test_lstm_autoencoder_fit_predict_encode_shapes():
+    """LSTMAutoencoder should reconstruct sequence input."""
+    X = np.random.randn(16, 5, 3).astype("float32")
+
+    ae = LSTMAutoencoder(
+        k=4,
+        hidden=(8, 6),
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 4)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+def test_cnn_autoencoder_fit_predict_encode_shapes():
+    """CNNAutoencoder should reconstruct channels-first image/grid input."""
+    X = np.random.randn(16, 1, 8, 8).astype("float32")
+
+    ae = CNNAutoencoder(
+        k=4,
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 4)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Current ViT decoder appears to send d_model-sized tokens directly to "
+        "Unpatchify, which expects patch_size*patch_size*C tokens. Add a decoder "
+        "projection from d_model to patch dimension before unpatchify."
+    ),
+    strict=False,
+)
+def test_vit_autoencoder_d_model_can_differ_from_patch_dimension():
+    """
+    VisionTransformerAutoencoder should allow d_model != patch_size*patch_size*C.
+
+    For C=1 and patch_size=4, patch dimension is 16.
+    This test uses d_model=8 to catch missing decoder projection bugs.
+    """
+    X = np.random.randn(16, 1, 8, 8).astype("float32")
+
+    ae = VisionTransformerAutoencoder(
+        k=4,
+        patch_size=4,
+        d_model=8,
+        depth_enc=1,
+        depth_dec=1,
+        heads=2,
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 4)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Current ConvLSTMAutoencoder returns a single frame but default fit(X) "
+        "uses the full 5D input as target. Either fit should use X[:, -1] as the "
+        "target or the decoder should reconstruct the full sequence."
+    ),
+    strict=False,
+)
+def test_convlstm_autoencoder_default_fit_reconstructs_documented_single_frame():
+    """
+    ConvLSTMAutoencoder example/docstring says fit(X) should work and predict
+    returns a single reconstructed frame with shape (B, C, H, W).
+    """
+    X = np.random.randn(16, 3, 1, 8, 8).astype("float32")
+
+    ae = ConvLSTMAutoencoder(
+        k=4,
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X[:, -1].shape
+    assert Z.shape == (16, 4)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Current HybridConvLSTMTransformerAutoencoder appears to reference "
+        "self.efficient_attention inside the inner model without assigning it. "
+        "It also has the same single-frame vs full-sequence fit target mismatch "
+        "as ConvLSTMAutoencoder."
+    ),
+    strict=False,
+)
+def test_hybrid_autoencoder_default_fit_reconstructs_documented_single_frame():
+    """
+    HybridConvLSTMTransformerAutoencoder example/docstring says fit(X) should
+    work and predict returns a single reconstructed frame with shape (B, C, H, W).
+    """
+    X = np.random.randn(16, 3, 1, 8, 8).astype("float32")
+
+    ae = HybridConvLSTMTransformerAutoencoder(
+        k=4,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        efficient_attention="linear",
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X[:, -1].shape
+    assert Z.shape == (16, 4)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Current StandardAutoencoder docstring says multidimensional inputs are "
+        "flattened, but _build_model appears to use only input_shape[-1] as the "
+        "feature count. Either restrict StandardAutoencoder to 2D input or make "
+        "flattening consistent in build, fit, predict, and loss target handling."
+    ),
+    strict=False,
+)
+def test_standard_autoencoder_multidimensional_flatten_contract():
+    """
+    Document the current ambiguity in StandardAutoencoder.
+
+    The docstring says multidimensional inputs are automatically flattened.
+    If that is intended, fit/predict should work for (B, C, H) input.
+    """
+    X = np.random.randn(16, 2, 5).astype("float32")
+
+    ae = StandardAutoencoder(
+        k=3,
+        hidden_dims=[8],
+        device="cpu",
+    )
+
+    history = ae.fit(X, **_fit_kwargs())
+    X_hat = ae.predict(X, batch_size=4, verbose=0)
+    Z = ae.encode(X, batch_size=4, verbose=0)
+
+    assert set(history) == {"train_loss", "val_loss"}
+    assert X_hat.shape == X.shape
+    assert Z.shape == (16, 3)
+    assert np.isfinite(X_hat).all()
+    assert np.isfinite(Z).all()

--- a/tests/test_deeplearning_autoencoders.py
+++ b/tests/test_deeplearning_autoencoders.py
@@ -24,6 +24,7 @@ from bluemath_tk.deeplearning.autoencoders import (
     LSTMAutoencoder,
     OrthogonalAutoencoder,
     StandardAutoencoder,
+    VisionTransformerAutoencoder,
 )
 
 
@@ -134,14 +135,6 @@ def test_cnn_autoencoder_fit_predict_encode_shapes():
     assert np.isfinite(Z).all()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Current ViT decoder appears to send d_model-sized tokens directly to "
-        "Unpatchify, which expects patch_size*patch_size*C tokens. Add a decoder "
-        "projection from d_model to patch dimension before unpatchify."
-    ),
-    strict=False,
-)
 def test_vit_autoencoder_d_model_can_differ_from_patch_dimension():
     """
     VisionTransformerAutoencoder should allow d_model != patch_size*patch_size*C.
@@ -172,14 +165,6 @@ def test_vit_autoencoder_d_model_can_differ_from_patch_dimension():
     assert np.isfinite(Z).all()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Current ConvLSTMAutoencoder returns a single frame but default fit(X) "
-        "uses the full 5D input as target. Either fit should use X[:, -1] as the "
-        "target or the decoder should reconstruct the full sequence."
-    ),
-    strict=False,
-)
 def test_convlstm_autoencoder_default_fit_reconstructs_documented_single_frame():
     """
     ConvLSTMAutoencoder example/docstring says fit(X) should work and predict
@@ -203,15 +188,6 @@ def test_convlstm_autoencoder_default_fit_reconstructs_documented_single_frame()
     assert np.isfinite(Z).all()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Current HybridConvLSTMTransformerAutoencoder appears to reference "
-        "self.efficient_attention inside the inner model without assigning it. "
-        "It also has the same single-frame vs full-sequence fit target mismatch "
-        "as ConvLSTMAutoencoder."
-    ),
-    strict=False,
-)
 def test_hybrid_autoencoder_default_fit_reconstructs_documented_single_frame():
     """
     HybridConvLSTMTransformerAutoencoder example/docstring says fit(X) should
@@ -239,15 +215,6 @@ def test_hybrid_autoencoder_default_fit_reconstructs_documented_single_frame():
     assert np.isfinite(Z).all()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Current StandardAutoencoder docstring says multidimensional inputs are "
-        "flattened, but _build_model appears to use only input_shape[-1] as the "
-        "feature count. Either restrict StandardAutoencoder to 2D input or make "
-        "flattening consistent in build, fit, predict, and loss target handling."
-    ),
-    strict=False,
-)
 def test_standard_autoencoder_multidimensional_flatten_contract():
     """
     Document the current ambiguity in StandardAutoencoder.


### PR DESCRIPTION
This PR fixes the implementation issues documented by the autoencoder smoke tests.

Changes include:
- Fix StandardAutoencoder and OrthogonalAutoencoder multidimensional flatten/reconstruction handling
- Add a ViT decoder projection from d_model tokens back to patch-dimension tokens before Unpatchify
- Make ConvLSTMAutoencoder reconstruct the last frame by default when y is not provided
- Make HybridConvLSTMTransformerAutoencoder reconstruct the last frame by default when y is not provided
- Store efficient_attention in the hybrid inner model
- Pass ConvLSTM kernel_size as a tuple
- Use deepcopy for best model state restoration

Local test result on Windows / Anaconda:
213 passed.